### PR TITLE
Add ability to add events with a single date and time in the future

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -151,7 +151,7 @@ def _validate_event_from_request(event: dict):
             if not time_setup[c.TIME]:
                 return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "No start time provided!"}), 400
         
-            if not re.match(c.TIME_PATTERN, time_setup[c.TIME_PATTERN]):
+            if not re.match(c.TIME_PATTERN, time_setup[c.TIME]):
                 return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "Invalid time format!"}), 400
         
         return None

--- a/src/app.py
+++ b/src/app.py
@@ -86,7 +86,7 @@ def _validate_authorization(request):
      return None
      
 def _validate_api_key(request):
-    return request.headers.get('X-API-KEY') ==  appConfig.api_key
+    return request.headers.get(c.X_API_KEY) ==  appConfig.api_key
 
 def _validate_event_from_request(event: dict):
         valid_attributes = {c.EVENT_NAME, c.MESSAGE, c.RECIPIENT, c.OWNER, c.TIME_SETUP}
@@ -114,13 +114,25 @@ def _validate_event_from_request(event: dict):
         if not all(time_attributes in time_setup for time_attributes in ("days", "type")):
             return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "Missing required time setup fields!"}), 400
         
-        if time_setup[c.TYPE] not in (c.ABSOLUTE, c.RANGE):
+        if time_setup[c.TYPE] not in (c.ABSOLUTE, c.RANGE, c.DATE):
             return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "time_setup type field not valid!"}), 400
-
-        valid_days = [c.DAILY, c.MONDAY, c.TUESDAY, c.WEDNESDAY, c.THURSDAY, c.FRIDAY, c.SATURDAY, c.SUNDAY]
-        if not all(day in valid_days for day in time_setup[c.DAYS]):
-            return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "Invalid days provided!"}), 400
         
+
+        if time_setup[c.TYPE] == c.ABSOLUTE or time_setup[c.TYPE] == c.RANGE:
+            valid_days = [c.DAILY, c.MONDAY, c.TUESDAY, c.WEDNESDAY, c.THURSDAY, c.FRIDAY, c.SATURDAY, c.SUNDAY]
+            if not all(day in valid_days for day in time_setup[c.DAYS]):
+                return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "Invalid days provided!"}), 400
+        elif time_setup[c.TYPE] == c.DATE:
+            if len(time_setup[c.DAYS]) > 1:
+                return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "Only one date allowed!"}), 400
+            try:
+                input_date = datetime.strptime(time_setup[c.DAYS][0], '%Y-%m-%d').date()
+                today = datetime.today().date()
+                if input_date < today:
+                    return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "Date should not be in the past!"}), 400
+            except ValueError:
+                return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "Date should have format %Y-%m-%d!"}), 400
+
         if time_setup[c.TYPE] == c.RANGE:
             if not time_setup[c.START]:
                 return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "No start time provided!"}), 400
@@ -135,7 +147,7 @@ def _validate_event_from_request(event: dict):
             if start_time >= end_time:
                 return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "Start time must be earlier than end time!"}), 400
             
-        elif time_setup[c.TIME] == c.ABSOLUTE:
+        elif time_setup[c.TYPE] == c.ABSOLUTE or time_setup[c.TYPE] == c.DATE:
             if not time_setup[c.TIME]:
                 return jsonify({c.STATUS: c.ERROR, c.MESSAGE: "No start time provided!"}), 400
         

--- a/src/config/configuration.py
+++ b/src/config/configuration.py
@@ -47,6 +47,7 @@ STAGE = PROD_STAGE
 ABSOLUTE = "absolute"
 COLON = ":"
 DAILY = "daily"
+DATE = "date"
 DAYS = "days"
 DELETE = "DELETE"
 EMAIL = "email"
@@ -79,7 +80,7 @@ TIME_SETUP = "time_setup"
 TO = 'To'
 TYPE = "type"
 W = "w"
-DATE = "date"
+X_API_KEY = 'X-API-KEY'
 
 # DAYS 
 DAILY = "daily"

--- a/src/config/configuration.py
+++ b/src/config/configuration.py
@@ -34,6 +34,10 @@ class Config:
         self.password = config[env]['password']
         self.api_key = config[env]['api_key']
         self._is_init = True
+        if env == PROD_STAGE:
+            self.url = "http://localhost:8123"
+        else:
+            self.url = "http://localhost:8123"
 
 
 PROD_STAGE = 'Prod'
@@ -75,6 +79,7 @@ TIME_SETUP = "time_setup"
 TO = 'To'
 TYPE = "type"
 W = "w"
+DATE = "date"
 
 # DAYS 
 DAILY = "daily"

--- a/src/helpers/event_server_client.py
+++ b/src/helpers/event_server_client.py
@@ -1,0 +1,32 @@
+import requests
+import sys
+
+running_via_gunicorn = 'gunicorn' in sys.argv[0] or 'gunicorn' in sys.modules
+
+if running_via_gunicorn:
+    import src.config.configuration as c
+    import src.helpers.emailClient as emailClient
+    from src.config.logging_config import logging
+else:
+    import config.configuration as c
+    import helpers.emailClient as emailClient
+    from config.logging_config import logging
+
+appConfig = c.Config(c.STAGE)
+
+deleteEndpoint = "/deleteEvent"
+
+def deleteEvent(eventId):
+    logging.info(f"Deleting eventId: {eventId}")
+    headers = {
+        c.X_API_KEY : appConfig.api_key
+    }
+    params = {
+        c.ID : eventId
+    }
+    response = requests.delete(appConfig.url+deleteEndpoint, headers=headers, params=params)
+
+    if response.status_code == 200:
+        logging.info(f"Successfully deleted eventId: {eventId}")
+    else:
+        logging.info(f"Failed to delete eventId: {eventId}")


### PR DESCRIPTION
Create Scheduled events by sending a new event type called date events.

These date events must be scheduled for a date and time in the future.

Example json request:
```
{
    "event_name": "Sample date event",
    "message": "This is a date event",
    "recipient": "recipient",
    "time_setup": {
        "type": "date",
        "time": "00:10",
        "days": [
            "2023-11-18"
        ]
    },
    "owner": "owner-email"
}

```